### PR TITLE
Throw error message when trying to pair delivery to inactive supplier

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddDeliveryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddDeliveryCommand.java
@@ -18,6 +18,7 @@ import seedu.address.model.delivery.Delivery;
 import seedu.address.model.delivery.DeliveryWrapper;
 import seedu.address.model.delivery.SupplierIndex;
 import seedu.address.model.supplier.Supplier;
+import seedu.address.model.supplier.SupplierStatus;
 
 /**
  * Adds a delivery to the address book.
@@ -42,6 +43,7 @@ public class AddDeliveryCommand extends Command {
             + PREFIX_COST + "25.50 ";
     public static final String MESSAGE_SUCCESS = "New delivery added: %1$s";
     public static final String MESSAGE_DUPLICATE_DELIVERY = "Delivery is already added!!!";
+    public static final String MESSAGE_INACTIVE_SUPPLIER = "Supplier is currently inactive!!!";
     private final DeliveryWrapper deliveryWrapper;
     /**
      * Creates an AddDeliveryCommand to add the specified {@code deliveryToAdd}
@@ -53,9 +55,10 @@ public class AddDeliveryCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        //Need to update when list changes name
         Supplier sender = this.getSupplierBasedOnIndex(model);
-        System.out.println("sender not null");
+        if (sender.getStatus().equals(new SupplierStatus("inactive"))) {
+            throw new CommandException(MESSAGE_INACTIVE_SUPPLIER);
+        }
         deliveryWrapper.setDeliverySupplier(sender);
         Delivery deliveryToAdd = deliveryWrapper.getDelivery();
         if (model.hasDelivery(deliveryToAdd)) {

--- a/src/test/java/seedu/address/logic/commands/AddDeliveryCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddDeliveryCommandTest.java
@@ -54,10 +54,21 @@ public class AddDeliveryCommandTest {
 
     @Test
     public void execute_duplicateDelivery_throwsCommandException() {
-        DeliveryWrapper deliveryWrapper = TypicalDeliveryWrappers.getNullWrapper();
+        DeliveryWrapper deliveryWrapper = TypicalDeliveryWrappers.BREAD_WRAPPER;
         AddDeliveryCommand addDeliveryCommand = new AddDeliveryCommand(deliveryWrapper);
-        ModelStub modelStub = new ModelStubWithDelivery(TypicalDeliveries.APPLE);
+        ModelStub modelStub = new ModelStubWithDelivery(TypicalDeliveries.BREAD);
         assertThrows(CommandException.class, AddDeliveryCommand.MESSAGE_DUPLICATE_DELIVERY, () ->
+                addDeliveryCommand.execute(modelStub));
+    }
+
+    @Test
+    public void execute_inactiveSupplier_throwsCommandException() {
+        Supplier validSupplier = new SupplierBuilder().withStatus("inactive").build();
+        ModelStubAcceptingDeliveryAdded modelStub = new ModelStubAcceptingDeliveryAdded(validSupplier);
+        Delivery deliveryWithNullSender = new DeliveryBuilder().buildWithNullSender();
+        DeliveryWrapper wrapper = new DeliveryWrapper(deliveryWithNullSender, new SupplierIndex("1"));
+        AddDeliveryCommand addDeliveryCommand = new AddDeliveryCommand(wrapper);
+        assertThrows(CommandException.class, AddDeliveryCommand.MESSAGE_INACTIVE_SUPPLIER, () ->
                 addDeliveryCommand.execute(modelStub));
     }
 
@@ -224,7 +235,7 @@ public class AddDeliveryCommandTest {
      */
     private class ModelStubWithDelivery extends ModelStub {
         private final Delivery delivery;
-        private final Supplier supplier = TypicalSuppliers.ALICE;
+        private final Supplier supplier = TypicalSuppliers.BENSON;
         private final UniqueSupplierList uniqueSupplierList = new UniqueSupplierList();
         ModelStubWithDelivery(Delivery delivery) {
             requireNonNull(delivery);

--- a/src/test/java/seedu/address/testutil/TypicalDeliveryWrappers.java
+++ b/src/test/java/seedu/address/testutil/TypicalDeliveryWrappers.java
@@ -10,10 +10,9 @@ public class TypicalDeliveryWrappers {
 
     public static final DeliveryWrapper APPLE_WRAPPER = new DeliveryWrapper(TypicalDeliveries.APPLE,
             new SupplierIndex("1"));
-    public static final DeliveryWrapper APPLE_NULL_SENDER_WRAPPER = new DeliveryWrapper(
-            new DeliveryBuilder().withSender(null).build(), new SupplierIndex("1"));
+
     public static final DeliveryWrapper BREAD_WRAPPER = new DeliveryWrapper(TypicalDeliveries.BREAD,
-            new SupplierIndex("2"));
+            new SupplierIndex("1"));
 
 
     public static final DeliveryWrapper CAN_WRAPPER = new DeliveryWrapper((TypicalDeliveries.CAN),


### PR DESCRIPTION
fixes #182 
Inactive suppliers cannot be paired with new deliveries when using the AddDeliveryCommand